### PR TITLE
Add custom footer to config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 dist
 .next
 tsconfig.tsbuildinfo
+storybook-static/**

--- a/src/components/context/PickerConfigContext.tsx
+++ b/src/components/context/PickerConfigContext.tsx
@@ -22,6 +22,7 @@ export function PickerConfigProvider({ children, ...config }: Props) {
 
   return (
     <ConfigContext.Provider value={mergedConfig}>
+      Test
       {children}
     </ConfigContext.Provider>
   );

--- a/src/components/context/PickerConfigContext.tsx
+++ b/src/components/context/PickerConfigContext.tsx
@@ -22,7 +22,6 @@ export function PickerConfigProvider({ children, ...config }: Props) {
 
   return (
     <ConfigContext.Provider value={mergedConfig}>
-      Test
       {children}
     </ConfigContext.Provider>
   );

--- a/src/components/context/PickerContext.tsx
+++ b/src/components/context/PickerContext.tsx
@@ -35,6 +35,7 @@ export function PickerContextProvider({ children }: Props) {
   const emojiVariationPickerState = useState<DataEmoji | null>(null);
   const reactionsModeState = useState(reactionsDefaultOpen);
   const [isPastInitialLoad, setIsPastInitialLoad] = useState(false);
+  const customFooter = useState<React.ReactNode | null>(null);
 
   useMarkInitialLoad(setIsPastInitialLoad);
 
@@ -53,7 +54,8 @@ export function PickerContextProvider({ children }: Props) {
         searchTerm,
         skinToneFanOpenState,
         suggestedUpdateState,
-        reactionsModeState
+        reactionsModeState,
+        customFooter,
       }}
     >
       {children}
@@ -77,6 +79,7 @@ const PickerContext = React.createContext<{
   disallowMouseRef: React.MutableRefObject<boolean>;
   disallowedEmojisRef: React.MutableRefObject<Record<string, boolean>>;
   reactionsModeState: ReactState<boolean>;
+  customFooter: ReactState<React.ReactNode | null>;
 }>({
   activeCategoryState: [null, () => {}],
   activeSkinTone: [SkinTones.NEUTRAL, () => {}],
@@ -90,7 +93,8 @@ const PickerContext = React.createContext<{
   searchTerm: ['', () => new Promise<string>(() => undefined)],
   skinToneFanOpenState: [false, () => {}],
   suggestedUpdateState: [Date.now(), () => {}],
-  reactionsModeState: [false, () => {}]
+  reactionsModeState: [false, () => {}],
+  customFooter: [null, () =>{}]
 });
 
 type Props = Readonly<{

--- a/src/components/footer/Preview.tsx
+++ b/src/components/footer/Preview.tsx
@@ -69,9 +69,6 @@ export function PreviewBody() {
     const defaultText = variationPickerEmoji
       ? emojiName(variationPickerEmoji)
       : previewConfig.defaultCaption;
-      console.log('defaultText', defaultText)
-    
-      console.log(previewConfig.customFooter)
 
     return (
       <>
@@ -99,7 +96,7 @@ export function PreviewBody() {
             ) : null}
         </div>
         <div className={cx(styles.label)}>
-          {show ? emojiName(emoji) : defaultText}
+          {show ? emojiName(emoji) : previewConfig.customFooter ? null : defaultText}
         </div>
       </>
     );

--- a/src/components/footer/Preview.tsx
+++ b/src/components/footer/Preview.tsx
@@ -106,15 +106,6 @@ export function PreviewBody() {
   }
 }
 
-function SlackConnect() {
-  return <img
-  src={'https://orgorg.com/images/3p/slack/slack-mark.png'}
-  alt={'Connect to Slack'}
-  height={24}
-  width={24}
-/>
-}
-
 export type PreviewEmoji = null | {
   unified: string;
   originalUnified: string;

--- a/src/components/footer/Preview.tsx
+++ b/src/components/footer/Preview.tsx
@@ -72,7 +72,9 @@ export function PreviewBody() {
 
     return (
       <>
-        <div>
+        {!show && previewConfig.customFooter ? previewConfig.customFooter : 
+        (<>
+          <div>
           {show ? (
             <ViewOnlyEmoji
               unified={previewEmoji?.unified as string}
@@ -82,9 +84,7 @@ export function PreviewBody() {
               getEmojiUrl={getEmojiUrl}
               className={cx(styles.emoji)}
             />
-          ) : previewConfig.customFooter ? 
-              previewConfig.customFooter : 
-              defaultEmoji ? (
+          ) : defaultEmoji ? (
               <ViewOnlyEmoji
                 unified={emojiUnified(defaultEmoji)}
                 emoji={defaultEmoji}
@@ -94,12 +94,13 @@ export function PreviewBody() {
                 className={cx(styles.emoji)}
               />
             ) : null}
-        </div>
-        <div className={cx(styles.label)}>
-          {show ? emojiName(emoji) : previewConfig.customFooter ? null : defaultText}
-        </div>
+          </div>
+          <div className={cx(styles.label)}>
+            {show ? emojiName(emoji) : defaultText}
+          </div>
+        </>)}
       </>
-    );
+    )
   }
 }
 

--- a/src/components/footer/Preview.tsx
+++ b/src/components/footer/Preview.tsx
@@ -69,6 +69,9 @@ export function PreviewBody() {
     const defaultText = variationPickerEmoji
       ? emojiName(variationPickerEmoji)
       : previewConfig.defaultCaption;
+      console.log('defaultText', defaultText)
+    
+      console.log(previewConfig.customFooter)
 
     return (
       <>
@@ -82,16 +85,18 @@ export function PreviewBody() {
               getEmojiUrl={getEmojiUrl}
               className={cx(styles.emoji)}
             />
-          ) : defaultEmoji ? (
-            <ViewOnlyEmoji
-              unified={emojiUnified(defaultEmoji)}
-              emoji={defaultEmoji}
-              emojiStyle={emojiStyle}
-              size={45}
-              getEmojiUrl={getEmojiUrl}
-              className={cx(styles.emoji)}
-            />
-          ) : null}
+          ) : previewConfig.customFooter ? 
+              previewConfig.customFooter : 
+              defaultEmoji ? (
+              <ViewOnlyEmoji
+                unified={emojiUnified(defaultEmoji)}
+                emoji={defaultEmoji}
+                emojiStyle={emojiStyle}
+                size={45}
+                getEmojiUrl={getEmojiUrl}
+                className={cx(styles.emoji)}
+              />
+            ) : null}
         </div>
         <div className={cx(styles.label)}>
           {show ? emojiName(emoji) : defaultText}
@@ -99,6 +104,15 @@ export function PreviewBody() {
       </>
     );
   }
+}
+
+function SlackConnect() {
+  return <img
+  src={'https://orgorg.com/images/3p/slack/slack-mark.png'}
+  alt={'Connect to Slack'}
+  height={24}
+  width={24}
+/>
 }
 
 export type PreviewEmoji = null | {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -132,6 +132,7 @@ export type PreviewConfig = {
   defaultEmoji: string;
   defaultCaption: string;
   showPreview: boolean;
+  customFooter?: React.ReactNode;
 };
 
 const basePreviewConfig: PreviewConfig = {

--- a/stories/picker.stories.tsx
+++ b/stories/picker.stories.tsx
@@ -367,6 +367,8 @@ function Template(args) {
             );
             console.log(emoji, event);
           }}
+          previewConfig={{customFooter: (<div>Custom footer</div>), defaultCaption: undefined}}
+          
         />
       </div>
     </React.StrictMode>

--- a/stories/picker.stories.tsx
+++ b/stories/picker.stories.tsx
@@ -367,7 +367,7 @@ function Template(args) {
             );
             console.log(emoji, event);
           }}
-          previewConfig={{customFooter: (<div>Custom footer</div>), defaultCaption: undefined}}
+          previewConfig={{customFooter: (<div>Custom footer</div>)}}
           
         />
       </div>


### PR DESCRIPTION
@chris-orgorg 

Forked the emoji component project to be able to put a custom footer in there. I plan on passing in the "Connect to slack" button when the org hasn't yet connected to slack.

Default:
<img width="362" alt="Screenshot 2025-02-21 at 10 58 08 PM" src="https://github.com/user-attachments/assets/29f4d922-6681-46c1-8dbd-7fff06c2778d" />

Custom footer:
<img width="364" alt="Screenshot 2025-02-21 at 10 57 29 PM" src="https://github.com/user-attachments/assets/6828d5b4-e5a0-4043-9b9b-ead72f6d69ec" />
